### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server that enables control of Philips Hue lights through Claude and other LLM interfaces using the OpenHue CLI.
 
+<a href="https://glama.ai/mcp/servers/5ixz6hgw5u"><img width="380" height="200" src="https://glama.ai/mcp/servers/5ixz6hgw5u/badge" alt="OpenHue Server MCP server" /></a>
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (v16 or higher)


### PR DESCRIPTION
This PR adds a badge for the OpenHue MCP Server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/5ixz6hgw5u"><img width="380" height="200" src="https://glama.ai/mcp/servers/5ixz6hgw5u/badge" alt="OpenHue Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.